### PR TITLE
Fix clean build, rebuild, and incremental build of WinRTTurboModule for .g.cpp files

### DIFF
--- a/rnwinrt/module/WinRTTurboModule.props
+++ b/rnwinrt/module/WinRTTurboModule.props
@@ -30,8 +30,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <None Include="$(RnWinRTPath)module\WinRTTurboModule.targets" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="$(GeneratedFilesDir)\rnwinrt\*.g.cpp" />
     <ClCompile Include="$(RnWinRTPath)module\dllmain.cpp" />
     <ClCompile Include="$(RnWinRTPath)module\WinRTTurboModule.cpp" />
+    <!-- $(GeneratedFilesDir)\rnwinrt\*.g.cpp are added in RnWinRTAddGeneratedCppFiles -->
   </ItemGroup>
 </Project>

--- a/rnwinrt/module/WinRTTurboModule.targets
+++ b/rnwinrt/module/WinRTTurboModule.targets
@@ -42,6 +42,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <CleanDependsOn>
             $(CleanDependsOn);CppWinRTClean
         </CleanDependsOn>
+        <BuildDependsOn>
+            RnWinRTAddGeneratedCppFiles;
+            $(BuildDependsOn)
+        </BuildDependsOn>
     </PropertyGroup>
 
     <ItemDefinitionGroup>
@@ -188,6 +192,21 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         </PropertyGroup>
         <Message Text="$(RnWinRTPathCommand)" Importance="$(RnWinRTVerbosity)" />
         <Exec Command="$(RnWinRTPathCommand)" />
+    </Target>
+
+    <!-- Generated files cannot be referenced for compile using $(GeneratedFilesDir)\rnwinrt\*.g.cpp because the list would not be
+         reevaluated after code generation. This would cause clean builds to fail and incremental builds to use a potentially stale list. -->
+    <Target Name="RnWinRTAddGeneratedCppFiles"
+            DependsOnTargets="RnWinRTMakeProjections">
+        <ItemGroup>
+            <_FilesToBuild Remove="@(_FilesToBuild)"/>
+            <_FilesToBuild Include="$(GeneratedFilesDir)rnwinrt\*.g.cpp"/>
+        </ItemGroup>
+        <ItemGroup>
+            <ClCompile Include="@(_FilesToBuild)" />
+            <FileWrites Include="@(_FilesToBuild)" />
+        </ItemGroup>
+        <Message Text="GeneratedCppFiles: @(_FilesToBuild)" Importance="$(RnWinRTVerbosity)" />
     </Target>
 
     <!-- Fast ABI component support -->


### PR DESCRIPTION
Presently, WinRTTurboModule.props includes the generated .g.cpp files using `<ClCompile Include="$(GeneratedFilesDir)\rnwinrt\*.g.cpp" />` but this is only evaluated when compilation begins and may contain no entries in the case of clean builds (or rebuilds) and stale entries in the case of incremental builds (e.g. if the filter now includes or excludes a namespace). 

The proposed workaround is to introduce RnWinRTAddGeneratedCppFiles in WinRTTurboModule.targets to add the list of .g.cpp files before build but after the code generation in RnWinRTMakeProjections.

I have verified that clean builds (and rebuild) now succeed and incremental builds (with no other changes) are no-op as expected.

Resolves #18