### PR TITLE
Remove incorrect FAIL_FAST in ProjectedEventInstance::~ProjectedEventInstance

### DIFF
--- a/rnwinrt/rnwinrt/strings/base.cpp
+++ b/rnwinrt/rnwinrt/strings/base.cpp
@@ -1274,11 +1274,6 @@ namespace WinRTTurboModule
     {
     }
 
-    ProjectedEventInstance::~ProjectedEventInstance()
-    {
-        FAIL_FAST_IF(!m_listeners.empty());
-    }
-
     std::vector<std::pair<jsi::Object, winrt::event_token>>::iterator ProjectedEventInstance::FindEntry(
         jsi::Runtime& runtime, const jsi::Object& object)
     {

--- a/rnwinrt/rnwinrt/strings/base.h
+++ b/rnwinrt/rnwinrt/strings/base.h
@@ -1048,7 +1048,6 @@ namespace WinRTTurboModule
     struct ProjectedEventInstance final
     {
         ProjectedEventInstance(std::shared_ptr<IProjectedEventBase> event);
-        virtual ~ProjectedEventInstance();
 
         const std::shared_ptr<IProjectedEventBase>& Event() const noexcept
         {


### PR DESCRIPTION
**Purpose**
See the explanation on #24. The FAIL_FAST is incorrect because it triggers on an expected scenario and needs to be removed.

Resolves #24 