### PR TITLE
Move a property setter to v2 interface

### DIFF
--- a/tests/WinRTTests/windows/TestComponent/TestComponent.idl
+++ b/tests/WinRTTests/windows/TestComponent/TestComponent.idl
@@ -109,15 +109,8 @@ namespace TestComponent
     delegate UInt32 InterwovenDelegate(Boolean inBool, out Boolean outBool, Int32 inNumeric, out Int32 outNumeric,
         Int32[] inArray, out Int32[] outArray, ref Int32[] fillArray);
 
-    [contract(TestContract, 2)]
-    [exclusiveto(Test)] 
-    interface ITest2
-    { 
-        Boolean BoolProperty{ set; };
-    };
-
     [contract(TestContract, 1)]
-    runtimeclass Test : ITest2
+    runtimeclass Test
     {
         // Constructors
         Test();
@@ -378,7 +371,11 @@ namespace TestComponent
         static Windows.Foundation.IAsyncOperation<Int32> ImmediateReturnAsync(Int32 value);
 
         // Member properties
-        Boolean BoolProperty { get; }; //Setter comes from ITest2 interface
+        Boolean BoolProperty { get; };
+        [contract(TestContract, 2)] 
+        {
+            Boolean BoolProperty { set; };
+        }
         Char CharProperty;
         UInt8 U8Property;
         UInt16 U16Property;


### PR DESCRIPTION
Moves one of the set properties of Test class to a separate interface to make sure the scenario works
Resolves #64 