### PR TITLE
Add instructions for compiling with /Zc:externConstexpr

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,11 @@ JavaScript WinRT (JS/WinRT) is a module for React Native Windows which provides 
 * Add [`WinRTTurboModule.vcxproj`](./samples/RNWinRTTestApp/windows/WinRTTurboModule/WinRTTurboModule.vcxproj) to your solution.
 * Make sure your project depends on the WinRTTurboModule project.
 * Turn off deploy for the WinRTTurboModule project.
+* Add `/Zc:externConstexpr` to the additional C++ compilation options for the WinRTTurboModule project
+  * OPTIONAL: You can also disable permissive mode (i.e. `/permissive-`) for the project
 * Add `import './WinRTTurboModule';` to your project's index.js.
-* Add 'PackageProviders().Append(winrt::WinRTTurboModule::ReactPackageProvider());' to your project's App.cpp
-* Add '#include <winrt\WinRTTurboModule.h>' to your project's pch.h
+* Add `PackageProviders().Append(winrt::WinRTTurboModule::ReactPackageProvider());` to your project's App.cpp
+* Add `#include <winrt\WinRTTurboModule.h>` to your project's pch.h
 * Create `WinRTTurboModule.js` under your project (next to index.js) and copy the contents of [rnwinrt/js/WinRTTurboModule.js](./rnwinrt/js/WinRTTurboModule.js) to it.  This should be something like the following:
 ```
     import * as TurboModuleRegistry from 'react-native/Libraries/TurboModule/TurboModuleRegistry';


### PR DESCRIPTION
Refactor added this requirement. I've kind of neglected to update the instructions so far; doing that now