### PR TITLE
Remove deploy target

### DIFF
--- a/samples/RNWinRTTestApp/windows/WinRTTurboModule/WinRTTurboModule.vcxproj
+++ b/samples/RNWinRTTestApp/windows/WinRTTurboModule/WinRTTurboModule.vcxproj
@@ -152,5 +152,4 @@
     <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.210505.3\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.210505.3\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('$(RnWinRTDir)\build\native\WinRTTurboModule.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(RnWinRTDir)\build\native\WinRTTurboModule.targets'))" />
   </Target>
-  <Target Name="Deploy" />
 </Project>


### PR DESCRIPTION
When the "Deploy" target is removed, this removes the need to uncheck the deploy option after adding the WinRTTurboModule project to the app solution (deploy will be unchecked by default)