### PR TITLE
Add a remediation if a callback cannot be scheduled

### DIFF
--- a/rnwinrt/rnwinrt/react/strings/base.h
+++ b/rnwinrt/rnwinrt/react/strings/base.h
@@ -1284,7 +1284,9 @@ namespace rnwinrt
         Func callback;
         std::atomic_int ref_count{ 0 };
 
-        lifetime_tracker(Func callback) : callback(std::move(callback)) {}
+        lifetime_tracker(Func callback) : callback(std::move(callback))
+        {
+        }
 
         // Should copy *references* to this type, not the type itself
         lifetime_tracker(const lifetime_tracker&) = delete;
@@ -1407,9 +1409,7 @@ namespace rnwinrt
                     winrt::throw_last_error();
                 }
 
-                lifetime_tracker tracker([&] {
-                    ::SetEvent(event.get());
-                });
+                lifetime_tracker tracker([&] { ::SetEvent(event.get()); });
 
                 std::exception_ptr exception;
                 bool invoked = false;

--- a/rnwinrt/rnwinrt/react/strings/base.h
+++ b/rnwinrt/rnwinrt/react/strings/base.h
@@ -1275,6 +1275,91 @@ namespace rnwinrt
         }
     };
 
+    // React's CallInvoker type does not have a way to communicate failure back to us (i.e. if the provided function
+    // object won't run). So we instead capture an object that can track the lifetime of the function object so that we
+    // can determine if the function will never be called
+    template <typename Func>
+    struct lifetime_tracker
+    {
+        Func callback;
+        std::atomic_int ref_count{ 0 };
+
+        lifetime_tracker(Func callback) : callback(std::move(callback)) {}
+
+        // Should copy *references* to this type, not the type itself
+        lifetime_tracker(const lifetime_tracker&) = delete;
+        lifetime_tracker& operator=(const lifetime_tracker&) = delete;
+
+        struct reference
+        {
+            lifetime_tracker* target;
+
+            reference(lifetime_tracker* target) noexcept : target(target)
+            {
+                target->ref_count.fetch_add(1, std::memory_order_relaxed);
+            }
+
+            reference(const reference& other) noexcept : target(other.target)
+            {
+                if (target)
+                {
+                    target->ref_count.fetch_add(1, std::memory_order_relaxed);
+                }
+            }
+
+            reference(reference&& other) noexcept : target(other.target)
+            {
+                other.target = nullptr;
+            }
+
+            ~reference()
+            {
+                reset();
+            }
+
+            reference& operator=(const reference& other) noexcept
+            {
+                if (this != &other)
+                {
+                    reset();
+
+                    target = other.target;
+                    if (target)
+                    {
+                        target->ref_count.fetch_add(1, std::memory_order_relaxed);
+                    }
+                }
+
+                return *this;
+            }
+
+            reference& operator=(reference&& other) noexcept
+            {
+                std::swap(target, other.target);
+            }
+
+            void reset()
+            {
+                auto ptr = std::exchange(target, nullptr);
+                if (ptr)
+                {
+                    auto count = ptr->ref_count.fetch_sub(1, std::memory_order_acq_rel);
+                    if (count == 1) // Returns the previous value
+                    {
+                        ptr->callback();
+                    }
+                }
+            }
+        };
+
+        // Should only be called once; begins the reference tracking
+        reference begin() noexcept
+        {
+            assert(ref_count.load(std::memory_order_relaxed) == 0);
+            return reference(this);
+        }
+    };
+
     struct runtime_context
     {
         jsi::Runtime& runtime;
@@ -1322,8 +1407,19 @@ namespace rnwinrt
                     winrt::throw_last_error();
                 }
 
+                lifetime_tracker tracker([&] {
+                    ::SetEvent(event.get());
+                });
+
                 std::exception_ptr exception;
-                call_invoker([&]() {
+                bool invoked = false;
+                call_invoker([&, ref = tracker.begin()]() mutable {
+                    // Force the completion of the event once the callback completes so we don't need to wait for the
+                    // lambda to be destroyed if for some reason it isn't immediate. Note that this sets the callback
+                    // pointer to null, so there's no dangling reference anywhere
+                    auto forceComplete = std::move(ref);
+                    assert(tracker.ref_count.load(std::memory_order_relaxed) == 1);
+
                     try
                     {
                         fn();
@@ -1332,7 +1428,8 @@ namespace rnwinrt
                     {
                         exception = std::current_exception();
                     }
-                    ::SetEvent(event.get());
+
+                    invoked = true;
                 });
 
                 if (::WaitForSingleObject(event.get(), INFINITE) != WAIT_OBJECT_0)
@@ -1343,6 +1440,10 @@ namespace rnwinrt
                 if (exception)
                 {
                     std::rethrow_exception(exception);
+                }
+                else if (!invoked)
+                {
+                    throw winrt::hresult_error(JSCRIPT_E_CANTEXECUTE);
                 }
             }
         }

--- a/tests/RnWinRTTests/DelegateAndEventTests.js
+++ b/tests/RnWinRTTests/DelegateAndEventTests.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. 
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 /**
@@ -25,6 +25,9 @@ export function makeDelegateAndEventTestScenarios(pThis) {
         new TestScenario('Test::StaticCompositeStructEventHandler', runStaticCompositeStructEventHandler.bind(pThis)),
         new TestScenario('Test::StaticRefEventHandler', runStaticRefEventHandler.bind(pThis)),
         new TestScenario('Test::StaticObjectEventHandler', runStaticObjectEventHandler.bind(pThis)),
+
+        // Async Event Callbacks
+        new TestScenario('Async Event Handling', runAsyncEventHandler.bind(pThis)),
 
         // Static Delegates
         new TestScenario('Test::StaticInvokeBoolDelegate', runStaticBoolDelegate.bind(pThis)),
@@ -143,6 +146,27 @@ function runStaticRefEventHandler(scenario) {
 function runStaticObjectEventHandler(scenario) {
     var vals = TestValues.s32.valid.map(val => new TestComponent.TestObject(val));
     testStaticEventHandler.call(this, scenario, vals, 'staticobjecteventhandler', (arg) => TestComponent.Test.raiseStaticObjectEvent(arg));
+}
+
+function runAsyncEventHandler(scenario) {
+    this.runAsync(scenario, (resolve, reject) => {
+        var eventSender = undefined;
+        var eventValue = 0;
+
+        var handler = (sender, arg) => {
+            eventSender = sender;
+            eventValue = arg;
+        };
+        TestComponent.Test.addEventListener('staticnumericeventhandler', handler);
+
+        TestComponent.Test.raiseStaticNumericEventAsync(42)
+            .then(() => {
+                assert.equal(eventSender, null);
+                assert.equal(eventValue, 42);
+                resolve();
+            }).catch(reject)
+            .finally(() => TestComponent.Test.removeEventListener('staticnumericeventhandler', handler));
+    });
 }
 
 function runStaticObjectEventHandlerForNonActivableClass(scenario) {

--- a/tests/RnWinRTTests/windows/TestComponent/Test.cpp
+++ b/tests/RnWinRTTests/windows/TestComponent/Test.cpp
@@ -1010,6 +1010,12 @@ namespace winrt::TestComponent::implementation
         s_objectEventSource(nullptr, value);
     }
 
+    IAsyncAction Test::RaiseStaticNumericEventAsync(int32_t value)
+    {
+        co_await winrt::resume_background();
+        s_numericEventSource(nullptr, value);
+    }
+
     bool Test::StaticInvokeBoolDelegate(bool inputValue, BoolDelegate const& targetFn)
     {
         return targetFn(inputValue);

--- a/tests/RnWinRTTests/windows/TestComponent/Test.h
+++ b/tests/RnWinRTTests/windows/TestComponent/Test.h
@@ -232,6 +232,8 @@ namespace winrt::TestComponent::implementation
         static void RaiseStaticRefEvent(Windows::Foundation::IReference<int32_t> const& value);
         static void RaiseStaticObjectEvent(TestComponent::TestObject const& value);
 
+        static Windows::Foundation::IAsyncAction RaiseStaticNumericEventAsync(int32_t value);
+
         static bool StaticInvokeBoolDelegate(bool inputValue, BoolDelegate const& targetFn);
         static char16_t StaticInvokeCharDelegate(char16_t inputValue, CharDelegate const& targetFn);
         static int32_t StaticInvokeNumericDelegate(int32_t inputValue, NumericDelegate const& targetFn);

--- a/tests/RnWinRTTests/windows/TestComponent/TestComponent.idl
+++ b/tests/RnWinRTTests/windows/TestComponent/TestComponent.idl
@@ -300,6 +300,9 @@ namespace TestComponent
         static void RaiseStaticRefEvent(Windows.Foundation.IReference<Int32> value);
         static void RaiseStaticObjectEvent(TestObject value);
 
+        // Trigger event on a background thread
+        static Windows.Foundation.IAsyncAction RaiseStaticNumericEventAsync(Int32 value);
+
         // Static delegate invocation
         static Boolean StaticInvokeBoolDelegate(Boolean value, BoolDelegate targetFn);
         static Char StaticInvokeCharDelegate(Char value, CharDelegate targetFn);

--- a/tests/TestArtifacts/Projections.d.ts
+++ b/tests/TestArtifacts/Projections.d.ts
@@ -1,0 +1,11 @@
+//tslint:disable
+
+import './TestComponent';
+import './Windows';
+import './Windows.Foundation';
+import './Windows.Foundation.Collections';
+import './Windows.Foundation.Diagnostics';
+import './Windows.Foundation.Metadata';
+import './Windows.Foundation.Numerics';
+import './Windows.Web';
+import './Windows.Web.Http';

--- a/tests/TestArtifacts/TestComponent.d.ts
+++ b/tests/TestArtifacts/TestComponent.d.ts
@@ -356,6 +356,7 @@ declare namespace TestComponent {
         public static raiseStaticCompositeStructEvent(value: TestComponent.CompositeType): void;
         public static raiseStaticRefEvent(value: number | null): void;
         public static raiseStaticObjectEvent(value: TestComponent.TestObject): void;
+        public static raiseStaticNumericEventAsync(value: number): Windows.Foundation.WinRTPromise<void, void>;
         public static staticInvokeBoolDelegate(value: boolean, targetFn: TestComponent.BoolDelegate): boolean;
         public static staticInvokeCharDelegate(value: string, targetFn: TestComponent.CharDelegate): string;
         public static staticInvokeNumericDelegate(value: number, targetFn: TestComponent.NumericDelegate): number;

--- a/tests/TestArtifacts/compareGeneratedTypeScript.ps1
+++ b/tests/TestArtifacts/compareGeneratedTypeScript.ps1
@@ -18,6 +18,7 @@ function compareFiles
 }
 
 
+compareFiles "Projections.d.ts" $expectedFilesDir $generatedFilesDir
 compareFiles "TestComponent.d.ts" $expectedFilesDir $generatedFilesDir
 compareFiles "Windows.d.ts" $expectedFilesDir $generatedFilesDir
 compareFiles "Windows.Foundation.Collections.d.ts" $expectedFilesDir $generatedFilesDir


### PR DESCRIPTION
We're seeing an issue that can roughly be summarized by the following:

1. [JS code] Registers for a WinRT event
2. [Something] Causes RNW to reload the instance, effectively destroying the JSI Runtime, etc.
3. [WinRT code] Fires the event registered for in step (1)
4. [Turbo module] Uses `call_sync` to try and invoke the callback registered in step (1)
5. [RNW internals] Because the original runtime, etc. has been torn down, the request is dropped on the floor
6. [Turbo module] Waits for an event that will never get set and hangs the calling thread

The fix, as suggested to us, is to capture an object whose lifetime we can track in the lambda's capture. Therefore, if the lambda ever gets destroyed without being invoked (e.g. if it was immediately ignore or if the queue is flushed when the runtime is getting torn down), we will be able to detect it and abort.

This was tested by using a periodic timer (`ThreadPoolTimer`) to fire an event every one second with a JS callback and then use the same type to fire an event every 10 seconds that reloads the RNW instance. Before this change, you could observe many threads stuck waiting after executing for a while, and after this change no such stuck threads could be observed. 