### PR TITLE
Update publish script to use npm-packlist-cli

### DIFF
--- a/package/packfiles.old
+++ b/package/packfiles.old
@@ -1,22 +1,24 @@
-bin/rnwinrt.exe
-bin/rnwinrt.pdb
-index.d.ts
-index.js
-LICENSE
-module/dllmain.cpp
-module/WinRTTurboModule.cpp
-module/WinRTTurboModule.def
-module/WinRTTurboModule.h
-module/WinRTTurboModule.props
-module/WinRTTurboModule.targets
-package.json
-react-native.config.js
-README.md
-windows/WinRTTurboModule/packages.config
-windows/WinRTTurboModule/pch.cpp
-windows/WinRTTurboModule/pch.h
-windows/WinRTTurboModule/ReactPackageProvider.cpp
-windows/WinRTTurboModule/ReactPackageProvider.h
-windows/WinRTTurboModule/WinRTTurboModule.idl
-windows/WinRTTurboModule/WinRTTurboModule.vcxproj
-windows/WinRTTurboModule/WinRTTurboModule.vcxproj.filters
+[
+  "LICENSE",
+  "windows/WinRTTurboModule/packages.config",
+  "module/dllmain.cpp",
+  "windows/WinRTTurboModule/pch.cpp",
+  "windows/WinRTTurboModule/ReactPackageProvider.cpp",
+  "module/WinRTTurboModule.cpp",
+  "module/WinRTTurboModule.def",
+  "bin/rnwinrt.exe",
+  "windows/WinRTTurboModule/WinRTTurboModule.vcxproj.filters",
+  "windows/WinRTTurboModule/pch.h",
+  "windows/WinRTTurboModule/ReactPackageProvider.h",
+  "module/WinRTTurboModule.h",
+  "windows/WinRTTurboModule/WinRTTurboModule.idl",
+  "index.js",
+  "react-native.config.js",
+  "package.json",
+  "README.md",
+  "bin/rnwinrt.pdb",
+  "module/WinRTTurboModule.props",
+  "module/WinRTTurboModule.targets",
+  "index.d.ts",
+  "windows/WinRTTurboModule/WinRTTurboModule.vcxproj"
+]

--- a/scripts/publish-npm-package.cmd
+++ b/scripts/publish-npm-package.cmd
@@ -16,9 +16,7 @@ if %ERRORLEVEL% NEQ 0 (
 
 :: Do a dry run to verify that we're not publishing a ton of unnecessary files
 pushd %PACKAGE_ROOT_DIR%
-    call npx --yes npm-packlist > packfiles.new
-    sort packfiles.new > packfiles.new.temp
-    move /Y packfiles.new.temp packfiles.new > NUL
+    call npx --yes npm-packlist-cli > packfiles.new
     fc /c packfiles.old packfiles.new > NUL 2>&1
     set NEW_FILES_CHECK=%ERRORLEVEL%
 popd


### PR DESCRIPTION
`npm-packlist` was apparently updated so that it can no longer be invoked from the command line, so switching to use `npm-packlist-cli`