### PR TITLE
Correctly project "fill array" patterns in TypeScript

### DIFF
--- a/rnwinrt/rnwinrt/TypescriptWriter.h
+++ b/rnwinrt/rnwinrt/TypescriptWriter.h
@@ -445,7 +445,7 @@ public:
                 bool hasAtleastOneInParam = false;
                 for (auto&& [param, paramSignature] : methodSignature.params())
                 {
-                    if (param.Flags().Out())
+                    if (param.Flags().Out() && paramSignature->ByRef())
                     {
                         returnNameTypePairs.push_back(std::make_pair(param.Name(), paramSignature->Type()));
                         continue;

--- a/tests/TestArtifacts/TestComponent.d.ts
+++ b/tests/TestArtifacts/TestComponent.d.ts
@@ -1,7 +1,7 @@
 //tslint:disable
 
 declare namespace TestComponent {
-    type BoolArrayDelegate = (values: boolean[]) => { subset: boolean[]; outValue: boolean[]; returnValue: boolean[] };
+    type BoolArrayDelegate = (values: boolean[], subset: boolean[]) => { outValue: boolean[]; returnValue: boolean[] };
     
     type BoolDelegate = (value: boolean) => boolean;
     
@@ -11,13 +11,13 @@ declare namespace TestComponent {
         value: boolean;
     }
 
-    type CharArrayDelegate = (values: string[]) => { subset: string[]; outValue: string[]; returnValue: string[] };
+    type CharArrayDelegate = (values: string[], subset: string[]) => { outValue: string[]; returnValue: string[] };
     
     type CharDelegate = (value: string) => string;
     
     type CharDelegateWithOutParam = (value: string) => string;
     
-    type CompositeStructArrayDelegate = (values: TestComponent.CompositeType[]) => { subset: TestComponent.CompositeType[]; outValue: TestComponent.CompositeType[]; returnValue: TestComponent.CompositeType[] };
+    type CompositeStructArrayDelegate = (values: TestComponent.CompositeType[], subset: TestComponent.CompositeType[]) => { outValue: TestComponent.CompositeType[]; returnValue: TestComponent.CompositeType[] };
     
     type CompositeStructDelegate = (value: TestComponent.CompositeType) => TestComponent.CompositeType;
     
@@ -29,13 +29,13 @@ declare namespace TestComponent {
         bools: TestComponent.BooleanTypes;
     }
 
-    type EnumArrayDelegate = (values: TestComponent.TestEnum[]) => { subset: TestComponent.TestEnum[]; outValue: TestComponent.TestEnum[]; returnValue: TestComponent.TestEnum[] };
+    type EnumArrayDelegate = (values: TestComponent.TestEnum[], subset: TestComponent.TestEnum[]) => { outValue: TestComponent.TestEnum[]; returnValue: TestComponent.TestEnum[] };
     
     type EnumDelegate = (value: TestComponent.TestEnum) => TestComponent.TestEnum;
     
     type EnumDelegateWithOutParam = (value: TestComponent.TestEnum) => TestComponent.TestEnum;
     
-    type GuidArrayDelegate = (values: string[]) => { subset: string[]; outValue: string[]; returnValue: string[] };
+    type GuidArrayDelegate = (values: string[], subset: string[]) => { outValue: string[]; returnValue: string[] };
     
     type GuidDelegate = (value: string) => string;
     
@@ -62,9 +62,9 @@ declare namespace TestComponent {
         readonly magicValue: number;
     }
 
-    type InterwovenDelegate = (inBool: boolean, inNumeric: number, inArray: number[]) => { outBool: boolean; outNumeric: number; outArray: number[]; fillArray: number[]; returnValue: number };
+    type InterwovenDelegate = (inBool: boolean, inNumeric: number, inArray: number[], fillArray: number[]) => { outBool: boolean; outNumeric: number; outArray: number[]; returnValue: number };
     
-    type NumericArrayDelegate = (values: number[]) => { subset: number[]; outValue: number[]; returnValue: number[] };
+    type NumericArrayDelegate = (values: number[], subset: number[]) => { outValue: number[]; returnValue: number[] };
     
     type NumericDelegate = (value: number) => number;
     
@@ -83,13 +83,13 @@ declare namespace TestComponent {
         enum: TestComponent.TestEnum;
     }
 
-    type ObjectArrayDelegate = (values: TestComponent.TestObject[]) => { subset: TestComponent.TestObject[]; outValue: TestComponent.TestObject[]; returnValue: TestComponent.TestObject[] };
+    type ObjectArrayDelegate = (values: TestComponent.TestObject[], subset: TestComponent.TestObject[]) => { outValue: TestComponent.TestObject[]; returnValue: TestComponent.TestObject[] };
     
     type ObjectDelegate = (value: TestComponent.TestObject) => TestComponent.TestObject;
     
     type ObjectDelegateWithOutParam = (value: TestComponent.TestObject) => TestComponent.TestObject;
     
-    type RefArrayDelegate = (values: number[] | null) => { subset: number[] | null; outValue: number[] | null; returnValue: number[] | null };
+    type RefArrayDelegate = (values: number[] | null, subset: number[] | null) => { outValue: number[] | null; returnValue: number[] | null };
     
     type RefDelegate = (value: number | null) => number | null;
     
@@ -126,7 +126,7 @@ declare namespace TestComponent {
         public static removeEventListener(type: "objecteventhandler", listener: Windows.Foundation.EventHandler<TestComponent.TestObject>): void;
     }
 
-    type StringArrayDelegate = (values: string[]) => { subset: string[]; outValue: string[]; returnValue: string[] };
+    type StringArrayDelegate = (values: string[], subset: string[]) => { outValue: string[]; returnValue: string[] };
     
     type StringDelegate = (value: string) => string;
     
@@ -257,16 +257,16 @@ declare namespace TestComponent {
         public compositeStructArrayOutParam(values: TestComponent.CompositeType[]): { rot1: TestComponent.CompositeType[]; rot2: TestComponent.CompositeType[]; returnValue: TestComponent.CompositeType[] };
         public refArrayOutParam(values: number[] | null): { rot1: number[] | null; rot2: number[] | null; returnValue: number[] | null };
         public objectArrayOutParam(values: TestComponent.TestObject[]): { rot1: TestComponent.TestObject[]; rot2: TestComponent.TestObject[]; returnValue: TestComponent.TestObject[] };
-        public boolFillParam(): boolean[];
-        public charFillParam(): string[];
-        public numericFillParam(): number[];
-        public stringFillParam(): string[];
-        public guidFillParam(): string[];
-        public enumFillParam(): TestComponent.TestEnum[];
-        public compositeStructFillParam(): TestComponent.CompositeType[];
-        public refFillParam(): number[] | null;
-        public objectFillParam(): TestComponent.TestObject[];
-        public interwovenParams(inBool: boolean, inNumeric: number, inArray: number[]): { outBool: boolean; outNumeric: number; outArray: number[]; refArray: number[]; returnValue: number };
+        public boolFillParam(values: boolean[]): void;
+        public charFillParam(values: string[]): void;
+        public numericFillParam(values: number[]): void;
+        public stringFillParam(values: string[]): void;
+        public guidFillParam(values: string[]): void;
+        public enumFillParam(values: TestComponent.TestEnum[]): void;
+        public compositeStructFillParam(values: TestComponent.CompositeType[]): void;
+        public refFillParam(values: number[] | null): void;
+        public objectFillParam(values: TestComponent.TestObject[]): void;
+        public interwovenParams(inBool: boolean, inNumeric: number, inArray: number[], refArray: number[]): { outBool: boolean; outNumeric: number; outArray: number[]; returnValue: number };
         public raiseBoolEvent(value: boolean): void;
         public raiseCharEvent(value: string): void;
         public raiseNumericEvent(value: number): void;
@@ -337,16 +337,16 @@ declare namespace TestComponent {
         public static staticCompositeStructArrayOutParam(values: TestComponent.CompositeType[]): { rot1: TestComponent.CompositeType[]; rot2: TestComponent.CompositeType[]; returnValue: TestComponent.CompositeType[] };
         public static staticRefArrayOutParam(values: number[] | null): { rot1: number[] | null; rot2: number[] | null; returnValue: number[] | null };
         public static staticObjectArrayOutParam(values: TestComponent.TestObject[]): { rot1: TestComponent.TestObject[]; rot2: TestComponent.TestObject[]; returnValue: TestComponent.TestObject[] };
-        public static staticBoolFillParam(): boolean[];
-        public static staticCharFillParam(): string[];
-        public static staticNumericFillParam(): number[];
-        public static staticStringFillParam(): string[];
-        public static staticGuidFillParam(): string[];
-        public static staticEnumFillParam(): TestComponent.TestEnum[];
-        public static staticCompositeStructFillParam(): TestComponent.CompositeType[];
-        public static staticRefFillParam(): number[] | null;
-        public static staticObjectFillParam(): TestComponent.TestObject[];
-        public static staticInterwovenParams(inBool: boolean, inNumeric: number, inArray: number[]): { outBool: boolean; outNumeric: number; outArray: number[]; refArray: number[]; returnValue: number };
+        public static staticBoolFillParam(values: boolean[]): void;
+        public static staticCharFillParam(values: string[]): void;
+        public static staticNumericFillParam(values: number[]): void;
+        public static staticStringFillParam(values: string[]): void;
+        public static staticGuidFillParam(values: string[]): void;
+        public static staticEnumFillParam(values: TestComponent.TestEnum[]): void;
+        public static staticCompositeStructFillParam(values: TestComponent.CompositeType[]): void;
+        public static staticRefFillParam(values: number[] | null): void;
+        public static staticObjectFillParam(values: TestComponent.TestObject[]): void;
+        public static staticInterwovenParams(inBool: boolean, inNumeric: number, inArray: number[], refArray: number[]): { outBool: boolean; outNumeric: number; outArray: number[]; returnValue: number };
         public static raiseStaticBoolEvent(value: boolean): void;
         public static raiseStaticCharEvent(value: string): void;
         public static raiseStaticNumericEvent(value: number): void;

--- a/tests/TestArtifacts/Windows.Foundation.Collections.d.ts
+++ b/tests/TestArtifacts/Windows.Foundation.Collections.d.ts
@@ -16,7 +16,7 @@ declare namespace Windows.Foundation.Collections {
         readonly current: T;
         readonly hasCurrent: boolean;
         moveNext(): boolean;
-        getMany(): { items: T[]; returnValue: number };
+        getMany(items: T[]): number;
     }
 
     interface IKeyValuePair<K, V> {
@@ -70,7 +70,7 @@ declare namespace Windows.Foundation.Collections {
         readonly size: number;
         getAt(index: number): T;
         indexOf(value: T): { index: number; returnValue: boolean };
-        getMany(startIndex: number): { items: T[]; returnValue: number };
+        getMany(startIndex: number, items: T[]): number;
         length: number;
         readonly [index: number]: T;
         concat(...items: (T | ConcatArray<T>)[]): T[];
@@ -99,7 +99,7 @@ declare namespace Windows.Foundation.Collections {
         append(value: T): void;
         removeAtEnd(): void;
         clear(): void;
-        getMany(startIndex: number): { items: T[]; returnValue: number };
+        getMany(startIndex: number, items: T[]): number;
         replaceAll(items: T[]): void;
         length: number;
         [index: number]: T;

--- a/tests/TestArtifacts/Windows.Foundation.d.ts
+++ b/tests/TestArtifacts/Windows.Foundation.d.ts
@@ -306,7 +306,7 @@ declare namespace Windows.Foundation {
         public first(): Windows.Foundation.Collections.IIterator<Windows.Foundation.IWwwFormUrlDecoderEntry>;
         public getAt(index: number): Windows.Foundation.IWwwFormUrlDecoderEntry;
         public indexOf(value: Windows.Foundation.IWwwFormUrlDecoderEntry): { index: number; returnValue: boolean };
-        public getMany(startIndex: number): { items: Windows.Foundation.IWwwFormUrlDecoderEntry[]; returnValue: number };
+        public getMany(startIndex: number, items: Windows.Foundation.IWwwFormUrlDecoderEntry[]): number;
     }
 
     class WwwFormUrlDecoderEntry implements Windows.Foundation.IWwwFormUrlDecoderEntry {


### PR DESCRIPTION
Arrays that are declared as `ref T[]` in .idl are represented as `out` in the .winmd, however they are *not* marked as `ByRef` in the method signature. This pattern is special as the caller is the one to allocate space for the array (as opposed to the callee, which is true for `out T[]` params) and then the callee fills in the values (and typically returns an integer that represents the number of elements written to the array). This is correctly handled in the JS projection code. The caller allocates the storage (e.g. via `new Array(N)`) and passes the array as an argument to the function. This change updates the TypeScript .d.ts generation code to match.

Fixes #175 