### PR TITLE
Address code analysis warnings

### DIFF
--- a/rnwinrt/rnwinrt/react/strings/base.cpp
+++ b/rnwinrt/rnwinrt/react/strings/base.cpp
@@ -674,7 +674,7 @@ jsi::Value projected_object_instance::get(jsi::Runtime& runtime, const jsi::Prop
             fallbackValue = std::move(*fallback);
     }
 
-    return std::move(fallbackValue);
+    return fallbackValue;
 }
 
 void projected_object_instance::set(jsi::Runtime& runtime, const jsi::PropNameID& id, const jsi::Value& value)
@@ -825,6 +825,10 @@ winrt::hstring projected_value_traits<winrt::hstring>::as_native(jsi::Runtime& r
     PWSTR stringBuffer;
     HSTRING_BUFFER buffer;
     winrt::check_hresult(::WindowsPreallocateStringBuffer(static_cast<uint32_t>(len), &stringBuffer, &buffer));
+
+    // NOTE: WindowsPreallocateStringBuffer will only give back null if the string is empty, however we've already
+    // covered that case
+    _Analysis_assume_(buffer != nullptr);
 
     winrt::hstring result;
     try

--- a/rnwinrt/rnwinrt/react/strings/base.h
+++ b/rnwinrt/rnwinrt/react/strings/base.h
@@ -491,7 +491,7 @@ namespace rnwinrt
         {
             std::aligned_storage_t<BufferSize * sizeof(T), alignof(T)> buffer;
             T* pointer;
-        } m_data;
+        } m_data{};
     };
 
     // Used to capture a lambda whose capture includes non-copyable types in scenarios where a copy constructor is
@@ -1061,7 +1061,7 @@ namespace rnwinrt
         {
         }
 
-        shared_runtime_context(shared_runtime_context&& other) : pointer(other.pointer)
+        shared_runtime_context(shared_runtime_context&& other) noexcept : pointer(other.pointer)
         {
             other.pointer = nullptr;
         }
@@ -4294,7 +4294,7 @@ namespace rnwinrt
                     deleteCount -= assignCount;
                     insertCount -= assignCount;
 
-                    jsi::Array result(runtime, deleteCount + assignCount);
+                    jsi::Array result(runtime, static_cast<std::size_t>(deleteCount) + assignCount);
                     uint32_t i = 0;
                     while (assignCount-- > 0)
                     {


### PR DESCRIPTION
This addresses VSO bugs:
* 42680501
* 42680425
* 42680505
* 42680588

I was able to locally reproduce all but one issue (the arithmetic overflow one), however there should be relatively high confidence that this addresses that issue