### PR TITLE
Include a reverse mapping for enums to match TypeScript

### DIFF
--- a/rnwinrt/rnwinrt/react/ReactFileGenerator.cpp
+++ b/rnwinrt/rnwinrt/react/ReactFileGenerator.cpp
@@ -411,7 +411,7 @@ namespace rnwinrt::enums::%
             continue;
 
         auto constant = field.Constant();
-        std::string_view fieldValueAsString;
+        std::string fieldValueAsString;
 
         switch (constant.Type())
         {

--- a/rnwinrt/rnwinrt/react/ReactFileGenerator.cpp
+++ b/rnwinrt/rnwinrt/react/ReactFileGenerator.cpp
@@ -410,9 +410,24 @@ namespace rnwinrt::enums::%
         if (!field.Constant()) // Enums have a 'value__' data member we need to ignore
             continue;
 
+        auto constant = field.Constant();
+        std::string_view fieldValueAsString;
+
+        switch (constant.Type())
+        {
+        case ConstantType::Int32:
+            fieldValueAsString = std::to_string(constant.ValueInt32());
+            break;
+        case ConstantType::UInt32:
+            fieldValueAsString = std::to_string(constant.ValueUInt32());
+            break;
+        default:
+            continue;
+        }
+
         writer.write_fmt(R"^-^(
-        { "%"sv, static_cast<double>(winrt::%::%) },)^-^",
-            rnwinrt::camel_case{ field.Name() }, rnwinrt::cpp_typename{ enumData.type_def }, field.Name());
+        { "%"sv, %, "%"sv },)^-^",
+            rnwinrt::camel_case{ field.Name() }, fieldValueAsString, fieldValueAsString);
     }
 
     writer.write_fmt(R"^-^(

--- a/rnwinrt/rnwinrt/react/strings/base.cpp
+++ b/rnwinrt/rnwinrt/react/strings/base.cpp
@@ -216,7 +216,7 @@ jsi::Value static_enum_data::get_value(jsi::Runtime& runtime, std::string_view v
     }
 
     // Look for a matching value (reverse mapping)
-    itr = std::find_if(values.begin(), values.end(), [&](auto& mapping) { return std::to_string(static_cast<int32_t>(mapping.value)) == valueName; });
+    itr = std::find_if(values.begin(), values.end(), [&](auto& mapping) { return mapping.valueAsString == valueName; });
     if (itr != values.end())
     {
         return jsi::Value(runtime, make_string(runtime, itr->name));
@@ -244,7 +244,7 @@ std::vector<jsi::PropNameID> projected_enum::getPropertyNames(jsi::Runtime& runt
     {
         result.push_back(make_propid(runtime, mapping.name));
         // Reverse mapping (to match TypeScript enums)
-        result.push_back(make_propid(runtime, std::to_string(static_cast<int32_t>(mapping.value))));
+        result.push_back(make_propid(runtime, mapping.valueAsString));
     }
 
     return result;

--- a/rnwinrt/rnwinrt/react/strings/base.cpp
+++ b/rnwinrt/rnwinrt/react/strings/base.cpp
@@ -216,7 +216,7 @@ jsi::Value static_enum_data::get_value(jsi::Runtime& runtime, std::string_view v
     }
 
     // Look for a matching value (reverse mapping)
-    itr = std::find_if(values.begin(), values.end(), [&](auto& mapping) { return mapping.valueAsString == valueName; });
+    itr = std::find_if(values.begin(), values.end(), [&](auto& mapping) { return mapping.value_as_string == valueName; });
     if (itr != values.end())
     {
         return jsi::Value(runtime, make_string(runtime, itr->name));
@@ -244,7 +244,7 @@ std::vector<jsi::PropNameID> projected_enum::getPropertyNames(jsi::Runtime& runt
     {
         result.push_back(make_propid(runtime, mapping.name));
         // Reverse mapping (to match TypeScript enums)
-        result.push_back(make_propid(runtime, mapping.valueAsString));
+        result.push_back(make_propid(runtime, mapping.value_as_string));
     }
 
     return result;

--- a/rnwinrt/rnwinrt/react/strings/base.h
+++ b/rnwinrt/rnwinrt/react/strings/base.h
@@ -1543,7 +1543,7 @@ namespace rnwinrt
         {
             std::string_view name;
             double value;
-            std::string_view valueAsString;
+            std::string_view value_as_string;
         };
 
         constexpr static_enum_data(std::string_view name, span<const value_mapping> values) :

--- a/rnwinrt/rnwinrt/react/strings/base.h
+++ b/rnwinrt/rnwinrt/react/strings/base.h
@@ -1552,7 +1552,7 @@ namespace rnwinrt
 
         virtual jsi::Value create(jsi::Runtime& runtime) const override;
 
-        jsi::Value get_value(std::string_view valueName) const;
+        jsi::Value get_value(jsi::Runtime& runtime, std::string_view valueName) const;
 
         span<const value_mapping> values;
     };

--- a/rnwinrt/rnwinrt/react/strings/base.h
+++ b/rnwinrt/rnwinrt/react/strings/base.h
@@ -1543,6 +1543,7 @@ namespace rnwinrt
         {
             std::string_view name;
             double value;
+            std::string_view valueAsString;
         };
 
         constexpr static_enum_data(std::string_view name, span<const value_mapping> values) :

--- a/tests/RnWinRTTests/App.js
+++ b/tests/RnWinRTTests/App.js
@@ -19,6 +19,7 @@ import {
 import { Scenario } from './Scenario';
 import { styles } from './Styles';
 import { TestResult } from './TestCommon'
+import { makeEnumTestScenarios } from './EnumTests'
 import { makePropertiesTestScenarios } from './PropertiesTests'
 import { makeBasicFunctionTestScenarios } from './BasicFunctionTests'
 import { makeArrayTestScenarios } from './ArrayTests'
@@ -35,6 +36,9 @@ class App extends Component {
 
     testSuites = [
         {
+            name: "Enum Tests",
+            scenarios: makeEnumTestScenarios(this),
+        }, {
             name: "Property Tests",
             scenarios: makePropertiesTestScenarios(this),
         }, {

--- a/tests/RnWinRTTests/EnumTests.js
+++ b/tests/RnWinRTTests/EnumTests.js
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation. 
+// Licensed under the MIT License.
+
+/**
+ * @format
+ */
+
+import {
+    TestScenario,
+    assert,
+} from './TestCommon'
+
+export function makeEnumTestScenarios(pThis) {
+    return [
+        new TestScenario('Enum forward mapping', runEnumForwardMapping.bind(pThis)),
+        new TestScenario('Enum reverse mapping', runEnumReverseMapping.bind(pThis)),
+        new TestScenario('Enum keys', runEnumKeys.bind(pThis)),
+        new TestScenario('Enum non-mappings', runEnumNonMappings.bind(pThis)),
+    ];
+}
+
+function runEnumForwardMapping(scenario) {
+    this.runSync(scenario, () => {
+        assert.equal(TestComponent.TestEnum.first, 1);
+        assert.equal(TestComponent.TestEnum.second, 2);
+        assert.equal(TestComponent.TestEnum.third, 3);
+        assert.equal(TestComponent.TestEnum.fourth, 4);
+    });
+}
+
+function runEnumReverseMapping(scenario) {
+    this.runSync(scenario, () => {
+        assert.equal(TestComponent.TestEnum[1], "first");
+        assert.equal(TestComponent.TestEnum[2], "second");
+        assert.equal(TestComponent.TestEnum[3], "third");
+        assert.equal(TestComponent.TestEnum[4], "fourth");
+    });
+}
+
+function runEnumKeys(scenario) {
+    this.runSync(scenario, () => {
+        // keys only includes enum names and values
+        assert.equal(Object.keys(TestComponent.TestEnum).sort(), ["1", "2", "3", "4", "first", "fourth", "second", "third"]);
+    })
+}
+
+function runEnumNonMappings(scenario) {
+    this.runSync(scenario, () => {
+        // case must match
+        assert.undefined(TestComponent.TestEnum.First);
+        // only enum values match, not other numbers
+        assert.undefined(TestComponent.TestEnum[0]);
+        // strings are not matched as numbers
+        assert.undefined(TestComponent.TestEnum["1.0"]);
+    });
+}

--- a/tests/RnWinRTTests/TestCommon.js
+++ b/tests/RnWinRTTests/TestCommon.js
@@ -92,6 +92,12 @@ export const assert = {
         }
     },
 
+    undefined(val) {
+        if (typeof val !== "undefined") {
+            throw new Error('assertUndefined failed!');
+        }
+    },
+
     equal(lhs, rhs) {
         var result = checkEquals(lhs, rhs);
         if (!result.success) {


### PR DESCRIPTION
This makes projected enums match TypeScript enums, which include [reverse mappings](https://www.typescriptlang.org/docs/handbook/enums.html#reverse-mappings)

Before: `{"aad": 2, "msa": 1, "unknown": 0}`
After: `{"0": "unknown", "1": "msa", "2": "aad", "aad": 2, "msa": 1, "unknown": 0}`

I tested by compiling rnwinrt.exe and then using it in our project to generate code.